### PR TITLE
Compile maintenant avec cl sur windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ default:
 test: clean
 	mkdir -p build/test/reports
 	$(CC) $(CFLAGS) -o build/test/tests test/CatchMain.cpp
-	build/test/tests #-r junit -o build/test/reports/test-reports.xml
+	build/test/tests
 clean:
 	rm -rf build
 

--- a/MakefileWindows
+++ b/MakefileWindows
@@ -1,13 +1,11 @@
-CC=g++
-CFLAGS=-Wall
 
 default:
 	mkdir build\bin
-	$(CC) $(CFLAGS) -o build\bin\sbet-decoder src\sbet-decoder.cpp
-	$(CC) $(CFLAGS) -o build\bin\accuracy-decoder src\accuracy-decoder.cpp
+	call "%windows10_x64_BUILD_TOOLS_ROOT%\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64 && cd build\\bin &&cl ..\\..\\src\\sbet-decoder.cpp /EHsc /Fesbet-decoder.exe
+	call "%windows10_x64_BUILD_TOOLS_ROOT%\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64 && cd build\\bin &&cl ..\\..\\src\\accuracy-decoder.cpp /EHsc /Feaccuracy-decoder.exe
 test: clean
 	mkdir build\test\reports
-	$(CC) $(CFLAGS) -o build\test\tests test\CatchMain.cpp
+	call "%windows10_x64_BUILD_TOOLS_ROOT%\\VC\\Auxiliary\\Build\\vcvarsall.bat" x64 && cd build\\test &&cl ..\\..\\test\\CatchMain.cpp /EHsc /Fetests.exe
 	build\test\tests.exe
 	
 clean:

--- a/MakefileWindows
+++ b/MakefileWindows
@@ -8,7 +8,7 @@ default:
 test: clean
 	mkdir build\test\reports
 	$(CC) $(CFLAGS) -o build\test\tests test\CatchMain.cpp
-	build\test\tests.exe #-r junit -o build\test\reports\test-reports.xml
+	build\test\tests.exe
 	
 clean:
 	if exist "build" rmdir /q /s build


### PR DESCRIPTION
Le compilateur windows (cl) n'aimait pas la façon dont le test-main.o de catch2 était réutiliser pour plusieurs fichier de test.